### PR TITLE
Manual toggle

### DIFF
--- a/plugins/solo-zootr-multiworld.lua
+++ b/plugins/solo-zootr-multiworld.lua
@@ -27,6 +27,8 @@ plugin.settings =
 	-- some people prefer to see the world name I guess
 	{ name='othernames', type='select', label='Show Other Names As',
 		options={'Someone', 'Link #', 'World #'}, default='Someone' },
+	{ name='shufflemode', type='select', label='Shuffle Mode',
+		options={shuffle_random, shuffle_manual}, default=shuffle_random },
 
 	-- add an info block for the required settings
 	{ type='info', text=EXPANSION_WARNING, }

--- a/plugins/solo-zootr-multiworld.lua
+++ b/plugins/solo-zootr-multiworld.lua
@@ -18,6 +18,9 @@ local plugin = {}
 -- this setting is crucially important! without it, loading states will crash
 local EXPANSION_WARNING = 'Enable "Use Expansion Slot" under Bizhawk\'s N64 menu!'
 
+local shuffle_random = 'Random'
+local shuffle_manual = 'Manual (P2 L Button)'
+
 plugin.name = "Solo ZOOTR Multiworld"
 plugin.settings =
 {
@@ -135,6 +138,13 @@ end
 
 function plugin.on_setup(data, settings)
 	data.itemqueues = data.itemqueues or {}
+
+	if settings.shufflemode ~= shuffle_manual then
+		data.autoshuffle = true
+	else
+		data.autoshuffle = false
+	end
+	
 	for i = 1,20 do print(EXPANSION_WARNING) end
 end
 
@@ -186,6 +196,18 @@ function plugin.on_frame(data, settings)
 		while #data.itemqueues[player_num] < count do
 			print('internal count too high? adding a filler item')
 			table.insert(data.itemqueues[player_num], 0)
+		end
+		
+		-- see if we're initiating a manual shuffle
+		-- this is debounced in the main shuffler
+		if settings.shufflemode == shuffle_manual then
+			-- Check the L Button
+			local keyTable = joypad.get(2)
+			if keyTable.L == true then
+				data.manual_shuffle_request = true
+			else
+				data.manual_shuffle_request = false
+			end
 		end
 	end
 end

--- a/plugins/solo-zootr-multiworld.lua
+++ b/plugins/solo-zootr-multiworld.lua
@@ -18,17 +18,13 @@ local plugin = {}
 -- this setting is crucially important! without it, loading states will crash
 local EXPANSION_WARNING = 'Enable "Use Expansion Slot" under Bizhawk\'s N64 menu!'
 
-local shuffle_random = 'Random'
-local shuffle_manual = 'Manual (P2 L Button)'
-
 plugin.name = "Solo ZOOTR Multiworld"
 plugin.settings =
 {
 	-- some people prefer to see the world name I guess
 	{ name='othernames', type='select', label='Show Other Names As',
 		options={'Someone', 'Link #', 'World #'}, default='Someone' },
-	{ name='shufflemode', type='select', label='Shuffle Mode',
-		options={shuffle_random, shuffle_manual}, default=shuffle_random },
+	{ name='swapbutton', type='boolean', label='Force Game Swap on P2 L Button?' },
 
 	-- add an info block for the required settings
 	{ type='info', text=EXPANSION_WARNING, }
@@ -140,14 +136,7 @@ end
 
 function plugin.on_setup(data, settings)
 	data.itemqueues = data.itemqueues or {}
-
-	if settings.shufflemode ~= shuffle_manual then
-		data.autoshuffle = true
-	else
-		data.autoshuffle = false
-	end
-	
-	for i = 1,20 do print(EXPANSION_WARNING) end
+	for i = 1,10 do print(EXPANSION_WARNING) end
 end
 
 function plugin.on_game_load(data, settings)
@@ -199,18 +188,12 @@ function plugin.on_frame(data, settings)
 			print('internal count too high? adding a filler item')
 			table.insert(data.itemqueues[player_num], 0)
 		end
-		
-		-- see if we're initiating a manual shuffle
-		-- this is debounced in the main shuffler
-		if settings.shufflemode == shuffle_manual then
-			-- Check the L Button
-			local keyTable = joypad.get(2)
-			if keyTable.L == true then
-				data.manual_shuffle_request = true
-			else
-				data.manual_shuffle_request = false
-			end
-		end
+	end
+
+	if settings.swapbutton then
+		local currL = joypad.get(2).L
+		if not data.prevL and currL then swap_game() end
+		data.prevL = currL
 	end
 end
 

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -118,7 +118,7 @@ end
 
 -- get list of games
 function get_games_list()
-	local games = get_dir_contents(GAMES_FOLDER)
+	local games = get_dir_contents(GAMES_FOLDER,false)
 	local toremove = {}
 
 	-- find .cue files and remove the associated bin/iso

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -430,7 +430,7 @@ while true do
 		    if frame_count >= next_swap_time then swap_game() end	
 		else
 			if config['plugin_state'].manual_shuffle_request == true then
-				if frames_since_restart > 1 * 60 then
+				if frames_since_restart > 20 then
 					config['plugin_state'].manual_shuffle_request = false
 					swap_game()
 				end

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -20,17 +20,17 @@ STATES_FOLDER = GAMES_FOLDER .. '/.savestates'
 
 -- Check if folder exists --
 function folder_exists(strFolderName)
-  local fileHandle, strError = io.open(strFolderName.."\\*.*","r")
-  if fileHandle ~= nil then
-    io.close(fileHandle)
-    return true
-  else
-    if string.match(strError,"No such file or directory") then
-      return false
-    else
-      return true
-    end
-  end
+	local fileHandle, strError = io.open(strFolderName.."\\*.*","r")
+	if fileHandle ~= nil then
+		io.close(fileHandle)
+		return true
+	else
+		if string.match(strError,"No such file or directory") then
+			return false
+		else
+			return true
+		end
+	end
 end
 
 -- folders needed for the shuffler to run
@@ -99,7 +99,7 @@ end
 -- returns a table containing all files in a given directory
 function get_dir_contents(dir, update)
 	local TEMP_FILE = 'shuffler-src/.file-list.txt'
-    if update ~= false then
+	if update ~= false then
 		local cmd = 'ls ' .. dir .. ' > ' .. TEMP_FILE
 		if PLATFORM == 'WIN' then
 			cmd = 'dir ' .. dir .. ' /B > ' .. TEMP_FILE
@@ -118,7 +118,7 @@ end
 
 -- get list of games
 function get_games_list()
-	local games = get_dir_contents(GAMES_FOLDER,false)
+	local games = get_dir_contents(GAMES_FOLDER, false)
 	local toremove = {}
 
 	-- find .cue files and remove the associated bin/iso
@@ -181,7 +181,7 @@ end
 function get_next_game()
 	local prev = config['current_game'] or nil
 	local all_games = get_games_list()
-	
+
 	if config['plugin_state'].autoshuffle ~= false then
 		-- randomize it
 		-- remove the currently loaded game and see if there are any other options
@@ -197,16 +197,16 @@ function get_next_game()
 		-- there's probably a better way to do this.
 		local this_index = 1
 		for i = 1, #all_games do
-		    if prev == all_games[i] then
+			if prev == all_games[i] then
 				this_index = i
 			end
-	    end
+		end
 		-- check if we cycled
 		this_index = this_index + 1
 		if this_index > #all_games then
 			this_index = 1
 		end
-		
+
 		return all_games[this_index]
 	end
 end
@@ -431,8 +431,8 @@ while true do
 		else
 			if config['plugin_state'].manual_shuffle_request == true then
 				if frames_since_restart > 1 * 60 then
-				    config['plugin_state'].manual_shuffle_request = false
-				    swap_game()
+					config['plugin_state'].manual_shuffle_request = false
+					swap_game()
 				end
 			end
 		end


### PR DESCRIPTION
My goal was to make an option in the script to do ZOOTR multiworld with manual toggling of switching worlds.  That's how I'd personally want to race or play this.  Let me know if you want me to change or fix anything.

Design Changes/Decisions:
- I changed it so that the script can only call os.execute on startup.  This operation on windows makes ugly cmd prompt popups because of lua shortcomings.  This has the side effect of not allowing new ROMs in while the script is running, because now the ROMs are cached in the file at script startup.  If you feel that having that behavior is more important than the cmd prompt popups, I can change it back.
- I assigned the ZOOTR toggle to Player 2's L Button.  Player 1's L Button unfortunately toggles the minimap.  It's an arbitrary button that can be defined in the normal Bizhawk controller menus.

Still occurring:
- It seems like a lua savestate.load operation on at least N64 has 4 frames of white screen.  The normal Bizhawk savestate loading does not appear to have this problem.  It might be a Bizhawk issue.
- The load ROM and load savestate operations still have some sound annoyance.  Maybe moving the soundOff soundOn operations around could make it a little nicer.
- Possibly: (Last time I tried to run initial setup a day or two ago, it failed on sonic-rings, so I deleted it locally.  That bug might still exist unless it was fixed.)