### PR TITLE
MMDS: Rockman & Forte WonderSwan

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -25,6 +25,7 @@ plugin.description =
 	- Mega Man Wily Wars GEN
 	- Mega Man Battle Network 1-3 GBA
 	- Mega Man Legends/64
+	- Rockman & Forte WonderSwan (credit: kalimag)
 	- Mega Man Soccer (credit: kalimag)
 	- Mega Man Battle & Chase (credit: kalimag)
 ]]
@@ -311,6 +312,16 @@ local gamedata = {
 		maxhp=function() return mainmemory.read_s16_be(0x0B5260) end,
 		minhp=-40,
 		shield=function() return mainmemory.read_u8(0x0BBD85) end,
+	},
+	['rm&fws']={ -- Rockman & Forte: Mirai Kara no Chousensha (WonderSwan)
+		func=function()
+			return function() -- hp and life counter change in very inconvenient ways, generic_swap doesn't work well here
+				local hit_anim_changed, hit_anim = update_prev('hit_anim', mainmemory.read_u16_le(0x03CE) == 0x66F9)
+				local hp_changed, hp, prev_hp = update_prev('hp', mainmemory.read_u8(0x03B6))
+				return (hit_anim_changed and hit_anim) or --happens on pretty much everything including pits and spikes
+				       (hp_changed and hp < prev_hp and (hp > 0 or hit_anim)) -- slime damage and repeated hits while still in anim.
+			end
+		end,
 	},
 	['mmsoccer']={ -- Megaman's Soccer SNES
 		get_controlled_player = function() return mainmemory.read_u16_le(0x195A) end,

--- a/plugins/megaman-hashes.dat
+++ b/plugins/megaman-hashes.dat
@@ -326,3 +326,6 @@ C9BCF042                                 mmlegends-psx -- Mega Man Legends (USA)
 975FB63F                                 mmb&c-eu -- Megaman - Battle & Chase (Europe)
 8797220B                                 mmb&c-jp-1.0 -- Rockman - Battle & Chase (Japan) (v1.0)
 4F343C71                                 mmb&c-jp-1.1 -- Rockman - Battle & Chase (Japan) (v1.1)
+9F8829AA8EA523E8370CBB2ACD2ACCE056BB7958 rm&fws -- Rockman & Forte - Mirai Kara no Chousensha (Japan).ws
+38E0A889F287FDB98BAA1219C648C031A6682E44 rm&fws -- Rockman & Forte - Mirai Kara no Chousensha (Japan).ws [NikcDC's EnglishNames-v1.2.1.ips]
+A411AD38D0B6FE237E19F03F9B50E39B400DE034 rm&fws -- Rockman & Forte - Mirai Kara no Chousensha (Japan).ws [NikcDC's JapaneseNames-v1.2.1.ips]


### PR DESCRIPTION
Adds support for the obscure (?) [Rockman & Forte licensed sequel on the WonderSwan](https://en.wikipedia.org/wiki/Rockman_%26_Forte_Mirai_kara_no_Ch%C5%8Dsensha), including the translation patch.

It's a standard Mega Man game, but I didn't end up using `generic_swap` because the way the game changes hp and life counters caused a lot of spurious swaps, and I couldn't find any good values for `gamemeta.gmode`.