### PR TITLE
Make dump() more robust

### DIFF
--- a/shuffler.lua
+++ b/shuffler.lua
@@ -55,14 +55,16 @@ function dump(o)
 		if type(o) == 'table' then
 			local s = ''
 			for k,v in pairs(o) do
-				if type(k) ~= 'number' then k = string.format('"%s"', k) end
-				s = s..a..string.format('[%s] = %s,', k, _dump(v, "", ""))..b
+				s = s..a..string.format('[%s] = %s,', _dump(k, "", ""), _dump(v, "", ""))..b
 			end
 			return '{'..b..s..'}'..b
-		elseif type(o) == 'string' then
-			return string.format('"%s"', o)
-		else
+		elseif type(o) == 'number' or type(o) == 'boolean' or o == nil then
 			return tostring(o)
+		elseif type(o) == 'string' then
+			-- %q encloses in double quotes and escapes according to lua rules
+			return string.format('%q', o)
+		else -- functions, native objects, coroutines
+			error(string.format('Unsupported value of type "%s" in config.', type(o)))
 		end
 	end
 


### PR DESCRIPTION
This PR modifies `dump()` to escape string values and make key/value handling consistent.

Main differences are:

- strings may contain double quotes, backslashes and new lines
- table keys may be booleans and tables 
- other types that can't be sensibly serialized throw an error instead of getting stringified (this is subjective, but I think this would only ever happen due to new bugs)

This should not make any practical difference for the shuffler as-is, because all table keys are known strings and all string values currently found in the config are limited by rules for file names. It would only be relevant to future features and external plugins.