### PR TITLE
MMDS: MMX6 without acid rain

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -112,6 +112,14 @@ local function mmlegends(gamemeta)
 	end
 end
 
+local function mmx6_swap(gamemeta)
+	return function()
+		-- check the damage counter used for the stats screen. not incremented by acid rain damage
+		_, damage, prev_damage = update_prev('damage', gamemeta.getdamage())
+		return prev_damage ~= nil and damage > prev_damage
+	end
+end
+
 local function battle_and_chase_swap(gamemeta)
 	local player_addr = gamemeta.player_addr
 	local hit_states = {
@@ -248,15 +256,17 @@ local gamedata = {
 		getlc=function() return mainmemory.read_u8(0x0D1C45) end,
 		maxhp=function() return mainmemory.read_u8(0x0D1C47) end,
 	},
+	['mmx6psx-eu']={ -- Mega Man X6 PSX PAL
+		getdamage=function() return mainmemory.read_u32_le(0x0CCFB0) end,
+		func=mmx6_swap,
+	},
 	['mmx6psx-us']={ -- Mega Man X6 PSX NTSC-U
-		gethp=function() return bit.band(mainmemory.read_u8(0x0970FC), 0x7F) end,
-		getlc=function() return mainmemory.read_u8(0x0CCF09) end,
-		maxhp=function() return mainmemory.read_u8(0x0CCF2B) end,
+		getdamage=function() return mainmemory.read_u32_le(0x0CCF68) end,
+		func=mmx6_swap,
 	},
 	['mmx6psx-jp']={ -- Mega Man X6 PSX NTSC-J
-		gethp=function() return bit.band(mainmemory.read_u8(0x0987BC), 0x7F) end,
-		getlc=function() return mainmemory.read_u8(0x0CE5C9) end,
-		maxhp=function() return mainmemory.read_u8(0x0CE5EB) end,
+		getdamage=function() return mainmemory.read_u32_le(0x0CE628) end,
+		func=mmx6_swap,
 	},
 	['mm1gb']={ -- Mega Man I GB
 		gethp=function() return mainmemory.read_u8(0x1FA3) end,

--- a/plugins/megaman-hashes.dat
+++ b/plugins/megaman-hashes.dat
@@ -239,6 +239,7 @@ B226F7EC59283B05C1E276E2F433893F45027CAC mmx3snes-us -- Mega Man X 3 (U).smc
 24E0C305                                 mmx5psx-us -- Mega Man X5 (USA) [Improvement Project Addendum v1.11].xdelta
 24454CEE                                 mmx6psx-us -- Mega Man X6 (USA) (v1.0)
 F063F536                                 mmx6psx-us -- Mega Man X6 (USA) (v1.1)
+FEAAE93C                                 mmx6psx-eu -- Mega Man X6 (Europe)
 A4F84BEC                                 mmx6psx-jp -- Rockman X6 (Japan)
 2CFAEE20EA657F57CDCF0C7159B88D1339C9651D mm1gb -- Megaman (U) [T+Fre_terminus].gb
 5D598A14A2A35AF64FBB08828EB1D425472624F3 mm1gb -- Megaman (U) [T+Por_Emuboarding].gb


### PR DESCRIPTION
Replaces MMX6 logic to watch the damage counter that the game keeps for the end-of-level screen instead of the health counter.
This counter conveniently does not count acid rain, but does count deaths like pits and crushing.

Disclaimer: I have only done cursory testing in the first couple of stages