### PR TITLE
MMDS: Support MMX3 Zero Project

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -236,6 +236,16 @@ local gamedata = {
 		getlc=function() return mainmemory.read_u8(0x1FB4) end,
 		maxhp=function() return mainmemory.read_u8(0x1FD2) end,
 	},
+	['mmx3snes-zp-4.4']={ -- Mega Man X3 SNES + Zero Project 4.4
+		func=function()
+			return function()
+				local action_changed, action = update_prev('action', mainmemory.read_u8(0x09DA))
+				local ride_armor_iframes_changed, ride_armor_iframes = update_prev('ride_armor_iframes', mainmemory.read_s8(0x0CEE) > 0)
+				return (action_changed and (action == 12 or action == 14)) or -- hit or death
+				       (ride_armor_iframes_changed and ride_armor_iframes)
+			end
+		end,
+	},
 	['mmx3psx-eu']={ -- Mega Man X3 PSX PAL
 		gethp=function() return bit.band(mainmemory.read_u8(0x0D9091), 0x7F) end,
 		getlc=function() return mainmemory.read_u8(0x0D8743) end,

--- a/plugins/megaman-hashes.dat
+++ b/plugins/megaman-hashes.dat
@@ -230,7 +230,7 @@ A35EE942D8F7B5893E0BCF2426E439836A4AD27D mmx3snes-us -- Mega Man X 3 (U) [T+Por]
 BF8CE9F1EF4756AE4091D938AC6657DD3EFFB769 mmx3snes-us -- Mega Man X 3 (U) [T+Swe1.0_GCT].smc
 B226F7EC59283B05C1E276E2F433893F45027CAC mmx3snes-us -- Mega Man X 3 (U).smc
 8E0156FC7D6AF6F36B08A5E399C0284C6C5D81B8 mmx3snes-us -- Rockman X 3 (J).smc
-1445ACC59BBAED967B7A7A27444CA194A0A0C31B mmx3snes-eu -- Mega Man X3 (modded 4.4)
+1445ACC59BBAED967B7A7A27444CA194A0A0C31B mmx3snes-zp-4.4 -- Mega Man X3 (Zero Project 4.4)
 30776FC9                                 mmx3psx-eu -- Mega Man X3 (Europe)
 470B67F2                                 mmx3psx-jp -- Rockman X3 (Japan)
 314E06A8                                 mmx4psx-us


### PR DESCRIPTION
Adds support for the Zero Project hack (4.4) for MMX3

It was already somewhat working before, but Zero has a higher maximum health stored elsewhere in memory, which often makes `generic_swap` think the health value is invalid. Switching between X and Zero would also cause false-positive swaps if one of them has less health than the other, so I used a different way to detect damage.