### PR TITLE
MMDS: Add a number of bootleg games

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -35,9 +35,9 @@ plugin.description =
 	- Super Adventure Rockman PSX
 
 	Bootlegs:
-	- Zook Hero Z (aka Rockman DX6)
-	- Zook Hero 2 (aka Rockman X3)
-	- Zook Man ZX4 (aka Rockman & Crystal)
+	- Zook Hero Z (aka Rockman DX6) GBC
+	- Zook Hero 2 (aka Rockman X3) GBC
+	- Zook Man ZX4 (aka Rockman & Crystal) GBA
 	- Thunder Blast Man (aka Rocman X) GBC
 	- Rockman 8 GB / Rockman X4 GBC
 ]]

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -33,6 +33,13 @@ plugin.description =
 	- Mega Man Soccer
 	- Mega Man Battle & Chase
 	- Super Adventure Rockman PSX
+
+	Bootlegs:
+	- Zook Hero Z (aka Rockman DX6)
+	- Zook Hero 2 (aka Rockman X3)
+	- Zook Man ZX4 (aka Rockman & Crystal)
+	- Thunder Blast Man (aka Rocman X) GBC
+	- Rockman 8 GB / Rockman X4 GBC
 ]]
 
 local prevdata = {}

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -451,6 +451,31 @@ local gamedata = {
 		is_battle = function() return mainmemory.read_u8(0x0CCAD4) == 1 end,
 		func=super_adventure_rockman_swap,
 	},
+	['zook-hero'] = {
+		gethp=function() return memory.read_u8(0x52, "HRAM") end,
+		getlc=function() return memory.read_u8(0x60, "HRAM") end,
+		maxhp=function() return 20 end,
+	},
+	['zook-man-zx4'] = {
+		gethp=function() return memory.read_u8(0x1638, "IWRAM") end,
+		getlc=function() return memory.read_u8(0x1634, "IWRAM") end,
+		maxhp=function() return 11 end,
+	},
+	['rockman-and-crystal'] = {
+		gethp=function() return memory.read_u8(0x163C, "IWRAM") end,
+		getlc=function() return memory.read_u8(0x1638, "IWRAM") end,
+		maxhp=function() return 11 end,
+	},
+	['rocman-x-gb'] = {
+		gethp=function() return memory.read_u8(0x025B, "WRAM") end,
+		getlc=function() return memory.read_u8(0x5F, "HRAM") end,
+		maxhp=function() return 8 end,
+	},
+	['rockman-8-gb'] = {
+		gethp=function() return memory.read_u8(0x027C, "WRAM") end,
+		getlc=function() return memory.read_u8(0x025E, "WRAM") end,
+		maxhp=function() return 8 end,
+	},
 }
 
 local backupchecks = {

--- a/plugins/megaman-hashes.dat
+++ b/plugins/megaman-hashes.dat
@@ -338,3 +338,22 @@ B4A3FF3B72639F27D1A6F449B0335074AEB9E603 rockman-exe-ws -- Rockman EXE WS (Japan
 ED53EE78                                 super-adventure-rockman-psx-disc1 -- Super Adventure Rockman (Japan) (Disc 1) (Episode 1 Tsuki no Shinden)
 069C1736                                 super-adventure-rockman-psx-disc2 -- Super Adventure Rockman (Japan) (Disc 2) (Episode 2 Shitou! Wily Numbers)
 44748644                                 super-adventure-rockman-psx-disc3 -- Super Adventure Rockman (Japan) (Disc 3) (Episode 3 Saigo no Tatakai!!)
+271097C99BE5F60FBDB561875D006A622093FE70 zook-hero -- Luke Yingxiong Z (Unl) (Multicart Rip)
+1AB872C9491FBD5B88F7AC9DB86DE502C48A2333 zook-hero -- Luoke Ren DX6 (Unlicensed, Japanese) (CBA091) [Fixed]
+87644630FD5F2414E4499B2C81F0C2713A7F84E5 zook-hero -- Luoke Ren DX6 (Unlicensed, Japanese) (CBA091) [Fixed]
+222E8362DA7A7EB999150C367A305271C60661B6 zook-hero -- Luoke Ren DX6 (Unlicensed, Japanese) (CBA091) [Raw Dump]
+F130BA54DA95E734C0ED224A627D862A6979DC32 zook-hero -- Luke Yingxiong 2 - Zook Hero 2 (Unl) (Multicart Rip) [Header Fix]
+4BF85D9641E3B842A917474DCB49A8B7F282711B zook-hero -- Luke Yingxiong 2 - Zook Hero 2 (Unl) (Multicart Rip)
+7047B14EF12B45942CBB69889FBDC51ED687FB1B zook-hero -- Rockman DX3 (Unl) [C]
+70E5C1DAE3BF0AEE8DC901ABA9E66751F2C1FC01 zook-hero -- Rockman DX3 (C) (Unl) (GBC)
+6C1D24162F2682BB6E82FB09639F2E311FDA5AFF zook-hero -- Rockman DX3 (C) (Unl) (GB)
+F0B655C5B01870DA92C9EA84736CB005A4CC4F9C zook-man-zx4 -- Zook Man ZX4 (Luke Ren ZX4) (Unlicensed, Chinese)
+755C686AD485055A2AB884A42FE56FCE26180049 rockman-and-crystal -- Rockman & Crystal (Battle Network Rockman Crystal) (Unl)
+0793D0B91025748DB776330C873BFD8B5EC9E5EA rocman-x-gb -- Thunder Blast Man (World) (Unl)
+47CA6EC0753F316BB6EA01ACD41E57A160FDCBAC rocman-x-gb -- Thunder Blast Man (J) [C][t1]
+CC6878FBF1CA0C4A4F679BC81375C62AB737465B rocman-x-gb -- Thunder Blast Man (World) (Unl)
+C66C6D3DF5BDDD1BA0E49120E824279C58A20E57 rocman-x-gb -- Rocman X Gold
+2652B1DC116009EB762526DFA06CAA257542DE45 rocman-x-gb -- Rocman X Gold
+ADCE7712CE95C6FA67A45E03EB08F5B9C2981C49 rocman-x-gb -- Roc-Man X (Mono)
+3F9286D8396F9045C2FEF1F57ADB0F5980978986 rockman-8-gb -- Rockman 8 (Unl) (Multicart Rip) [MBC1 Hack]
+1F2524B452C6714B89C0BDCE8ED28028DD239141 rockman-8-gb -- Rockman X4 (Megaman X4) (Unl) [MBC5 Hack]


### PR DESCRIPTION
Adds support for some of the games from #27 

- Zook Hero Z (aka Rockman DX6)
- Zook Hero 2 (aka Rockman X3)
- Zook Man ZX4 (aka Rockman & Crystal)
- Thunder Blast Man (aka Rocman X) GBC
- Rockman 8 GB / Rockman X4 GBC