### PR TITLE
MMDS: Prevent spurious swaps during MMX5 boss rush

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -282,6 +282,7 @@ local gamedata = {
 		gethp=function() return bit.band(mainmemory.read_u8(0x09A0FC), 0x7F) end,
 		getlc=function() return mainmemory.read_u8(0x0D1C45) end,
 		maxhp=function() return mainmemory.read_u8(0x0D1C47) end,
+		gmode=function() return mainmemory.read_u8(0x09A0FC) ~= 0 or mainmemory.read_u8(0x0942BE) ~= 0 end,
 	},
 	['mmx6psx-eu']={ -- Mega Man X6 PSX PAL
 		getdamage=function() return mainmemory.read_u32_le(0x0CCFB0) end,


### PR DESCRIPTION
MMX5 sets the player health to 0 after exiting a stage, and restores it when entering a new stage. During the final boss rush, the transitions are quick and health stays at 0 for a single frame, which hits an edge case in `generic_swap`. HP at 0 fulfills `currhp < prevhp` and starts `data.hpcountdown`, but when `hpcountdown` reaches 0 health is back at its max value and fulfills `currhp > minhp`, swapping even though the life count hasn't decreased. This happens at the beginning and end of each boss rush fight.

https://github.com/authorblues/bizhawk-shuffler-2/blob/1f37b9719474275ebf44f8c0653bdda589e27e93/plugins/megaman-damage-shuffler.lua#L88-L100

It would probably be better to address this in `generic_swap`, either by not triggering `hpcountdown`  if `currhp` is 0, or by making sure `currhp` is still decreased when  `hpcountdown`  reaches 0, but I don't want to have to test that a potential fix doesn't break any other game using `generic_swap`, so this PR works around it with a `gmode` that seems to reliably indicate gameplay.