### PR TITLE
Plugin Submission -- Change Swap Timers Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,2 @@
-# Bizhawk Shuffler 2
-* written by authorblues, inspired by [Brossentia's Bizhawk Shuffler](https://github.com/brossentia/BizHawk-Shuffler), based on slowbeef's original project
-* [tested on Bizhawk v2.6.2](https://github.com/TASVideos/BizHawk/releases/tag/2.6.2)  
-  **Important:** BizHawk v2.6.3 is currently not supported
-* [click here to download the latest version](https://github.com/authorblues/bizhawk-shuffler-2/archive/refs/heads/main.zip)
-
-## Additional Resources
-* **[Setup Instructions](https://github.com/authorblues/bizhawk-shuffler-2/wiki/Setup-Instructions)**
-* [Frequently Asked Questions](https://github.com/authorblues/bizhawk-shuffler-2/wiki/Frequently-Asked-Questions) - important info!
-* [How to Create a Shuffler Plugin](https://github.com/authorblues/bizhawk-shuffler-2/wiki/How-to-Create-a-Shuffler-Plugin)
+Please note this is just a fork; all information related to credits and setup are over at the official release: https://github.com/authorblues/bizhawk-shuffler-2
+I'm just using this to store any plugins I end up writing. Thanks!

--- a/plugins/change-swap-timers-live.lua
+++ b/plugins/change-swap-timers-live.lua
@@ -1,0 +1,48 @@
+local plugin = {}
+
+plugin.name = "Change Swap Timers Live"
+plugin.author = "SushiKishi"
+plugin.settings = { 
+	{ name="timerFile", type="file", label="What file to use?" },
+
+}
+
+plugin.description =
+[[ NOTE: Using this plugin will render the Minimum and Maximum swap times on the setup window useless, as they are overwritten by the plugin. Make sure the setup file contains the times you want to start with before clicking on Start or Resume Session!
+
+This plugin allows you to use a separate .TXT file to update your minimum and maximum swap timers on the fly. This replicates a (probably unintended) feature of the first Bizhawk Shuffler where you could change these on the fly and they would apply without restarting the entire session. You can use this to offer, say, a donation incentive to speed up your swap timers. You'll need to modify this .TXT file yourself -- any sort of Twitch or chat interaction is beyond the scope of what I'm willing to deal with.
+
+There's a default settings file with the plugin, but the file can go wherever you choose. The format has to be specific, however. In case you lose the default file, the only two lines it contains are:
+
+config.min_swap=1
+config.max_swap=3
+
+Adjust your minimum/maximum times, in seconds, accordingly. Any kind of check to make sure you've put valid integers there that won't goof up the works is also beyond the scope of what I'm willing to learn -- I just wanted this feature quickly without having to learn how to code beyond the basics.
+
+Finally -- this directly changes the configuation of your Shuffler settings. This is only worth mentinoing because they won't go back to "default" at the start of a new session -- you'll have to modify the plugin's settings file directly every time you load this plugin if you need to revert them back.
+
+]]
+
+-- called once at the start
+-- This makes sure the first game swap of the new/resumed session
+-- has the same timers as the plugin's configuation file.
+-- Otherwise, it uses the numbers on the Shuffler's set-up screen.
+function plugin.on_setup(data, settings)
+	local liveTimers = loadfile(settings.timerFile) --load the settings file as set in Plugin config
+		if liveTimers ~= nil then -- if it exists / is not empty
+		liveTimers() -- execute the code inside -- which updates the config.[VARIABLES]
+		liveTimers = nil -- remove the file from memory; I mean, yeah, it's a small file, but no sense in it hanging around
+		end -- Ends the If/Then statement
+end -- Ends the On_Setup part of the plugin
+
+-- called each time a game/state is saved (before swap)
+function plugin.on_game_save(data, settings)
+	local liveTimers = loadfile(settings.timerFile) --load the settings file as set in Plugin config
+	if liveTimers ~= nil then -- if it exists / is not empty
+	liveTimers() -- execute the code inside -- which updates the config.[VARIABLES]
+	liveTimers = nil -- remove the file from memory; I mean, yeah, it's a small file, but no sense in it hanging around
+	end -- Ends the If/Then statement
+end -- Ends the on_game_Save part of the plugin
+
+
+return plugin

--- a/plugins/liveTimers.txt
+++ b/plugins/liveTimers.txt
@@ -1,0 +1,2 @@
+config.min_swap=1
+config.max_swap=3


### PR DESCRIPTION
A simple plugin that uses an external text file to allow players to change the swap timers on the fly. Use cases include donation incentives -- every $X dollars makes games swap Y seconds faster until end of stream, etc.

It doesn't access the configuration or other files directly, but the way that the changes are made to end up effecting the config.lua file in the end; the numbers entered for this plugin end up being the default settings when starting up a new session of the Shuffler. It loads the plugin's configuration file, executes the lines inside (config.min/max_swap = X), then unloads the file both at the start of a new/resumed Shuffler session and right before every game swap.

This might not be the right way to handle it in a plugin, especially if it's meant to be shared to others. It might make a better feature request, so that someone with more experience can add it in a way that couldn't eventually break things -- by allowing the user to add any kinds of code they want to the plugin config, for example.  I did try to figure out how to open the file and just look for the numeric values, then assign, say, config.swap_min = <config.txt line 1>, but ran into local / function variable errors. Most of my coding experience is in PHP; I imagine it's easy enough to do, but I wasn't able to figure out how to do it correctly with that approach.

I'm new to GitHub, so I made a fork to upload the plugin to to make the request. But I never like how GitHub doesn't make it obvious, especially if you're new or just looking for the daggone download link, whether you're looking at a fork or the original. So I modified the readme file so it would change the text on the front of my fork -- and now it's submitted that file as well. I'll try to take it out of the request, but I'll be honest, GitHub just confuses me most of the time so if I can't figure it out just know that, obviously, that wasn't part of the request.