### PR TITLE
Weighted shuffle

### DIFF
--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -285,8 +285,7 @@ function module.initial_setup(callback)
 		if config.shuffle_index == -2 then
 			config.game_weights = {}
 			for _,game in ipairs(games) do
-				-- on first shuffle these will be increased to 0
-				config.game_weights[game] = -1
+				config.game_weights[game] = 0
 			end
 		end
 

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -244,7 +244,7 @@ function module.initial_setup(callback)
 	end
 
 	local SWAP_MODES_DEFAULT = 'Random Order (Default)'
-	local SWAP_MODES = {[SWAP_MODES_DEFAULT] = -1, ['Fixed Order'] = 0, ['Prefer Lesser-Picked ROMs'] = -2}
+	local SWAP_MODES = {[SWAP_MODES_DEFAULT] = -1, ['Random (Boost Unpicked)'] = -2, ['Fixed Order'] = 0}
 
 	-- I believe none of these conflict with default Bizhawk hotkeys
 	local HOTKEY_OPTIONS = {
@@ -281,6 +281,14 @@ function module.initial_setup(callback)
 		config.shuffle_index = SWAP_MODES[forms.gettext(mode_combo)]
 		config.hk_complete = (forms.gettext(hk_complete) or 'Ctrl+Shift+End'):match("[^%s]+")
 		config.completed_games = {}
+
+		if config.shuffle_index == -2 then
+			config.game_weights = {}
+			for _,game in ipairs(games) do
+				-- on first shuffle these will be increased to 0
+				config.game_weights[game] = -1
+			end
+		end
 
 		config.plugins = {}
 		for _,plugin in ipairs(plugins) do

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -284,7 +284,7 @@ function module.initial_setup(callback)
 
 		if config.shuffle_index == -2 then
 			config.game_weights = {}
-			for _,game in ipairs(games) do
+			for _,game in ipairs(get_games_list(true)) do
 				config.game_weights[game] = 0
 			end
 		end

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -284,7 +284,7 @@ function module.initial_setup(callback)
 
 		if config.shuffle_index == -2 then
 			config.game_weights = {}
-			for _,game in ipairs(get_games_list(true)) do
+			for _,game in pairs(get_games_list()) do
 				config.game_weights[game] = 0
 			end
 		end

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -244,7 +244,7 @@ function module.initial_setup(callback)
 	end
 
 	local SWAP_MODES_DEFAULT = 'Random Order (Default)'
-	local SWAP_MODES = {[SWAP_MODES_DEFAULT] = -1, ['Fixed Order'] = 0}
+	local SWAP_MODES = {[SWAP_MODES_DEFAULT] = -1, ['Fixed Order'] = 0, ['Prefer Lesser-Picked ROMs'] = -2}
 
 	-- I believe none of these conflict with default Bizhawk hotkeys
 	local HOTKEY_OPTIONS = {

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -280,7 +280,6 @@ function pad_games_list(games, to_reset)
 		for i = 0, weight, -1 do
 			table.insert(games, game)
 		end
-		output = output .. game .. ': ' .. weight .. '\n'
 	end
 end
 

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -261,7 +261,7 @@ function get_next_game()
 		-- shuffle_index == -2 indicates games should be given multiple entries based on
 		-- their weight in config.game_weights
 		if config.shuffle_index == -2 then
-			config.game_weights[prev] = 0
+			if prev ~= nil then config.game_weights[prev] = 0 end
 			pad_games_list(all_games)
 		end
 		return all_games[math.random(#all_games)]
@@ -274,12 +274,21 @@ function get_next_game()
 end
 
 function pad_games_list(games)
-	for _,game in ipairs(games) do
+	-- copy the games list so we're not iterating over an ever-expanding list
+	local initial_games = {}
+	for _,game in pairs(games) do
+		table.insert(initial_games, game)
+	end
+	-- actual padding
+	for _,game in pairs(initial_games) do
 		-- accounting for new games
-		if config.game_weights[game] ~= nil then config.game_weights[game] = 0 end
-		-- pad the games list with (weight) copies of the game
-		for i = 0, config.game_weights[game] do
-			table.insert(games, game)
+		if config.game_weights[game] ~= nil then
+			-- pad the games list with (weight) copies of the game
+			for i = 0, config.game_weights[game] do
+				table.insert(games, game)
+			end
+		else
+			config.game_weights[game] = 0
 		end
 		config.game_weights[game] = config.game_weights[game] + 1
 	end

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -275,11 +275,11 @@ function pad_games_list(games, to_reset)
 	-- prevent re-entry
 	config.game_weights[to_reset] = -1
 	for game,weight in ipairs(config.game_weights) do
-		config.game_weights[game] = config.game_weights[game] + 1
 		-- pad the games list with (weight) copies of the game
 		for i = 0, weight, -1 do
 			table.insert(games, game)
 		end
+		config.game_weights[game] = config.game_weights[game] + 1
 	end
 end
 

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -253,7 +253,7 @@ function get_next_game()
 		all_games = get_games_list(true)
 	end
 
-	-- shuffle_index == -1 represents random shuffle order types
+	-- shuffle_index < 0 represents random shuffle order types
 	if config.shuffle_index < 0 then
 		-- remove the currently loaded game and see if there are any other options
 		table_subtract(all_games, { prev })

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -271,9 +271,8 @@ function get_next_game()
 end
 
 function pad_games_list(games, to_reset)
-	-- increase all weights by 1, except to_reset, which is explicitly set to -1 to
-	-- prevent re-entry
-	config.game_weights[to_reset] = -1
+	-- to_reset is explicitly set to 0 to prevent re-entry
+	config.game_weights[to_reset] = 0
 	for game,weight in ipairs(config.game_weights) do
 		-- pad the games list with (weight) copies of the game
 		for i = 0, weight, -1 do


### PR DESCRIPTION
Adds a **Random (Boost Unpicked)** option to the list of swap modes. This fudges the randomness a bit such that the longer a game goes without being picked, the more likely it is to get picked.

### Why?

For casual sessions, it can be desirable provide/showcase a broad variety that "feels" more random, even though it isn't.

### How?

Picking the **Random (Boost Unpicked)** swap mode will cause the shuffler to hang onto a `game_weights` table in the `config`. All game weights are initialized to `0`. When picking a game, the list of games to choose from is padded with copies of each game, based on its current game weight - except for the previously selected game, which is reset to `0`. All games then have their weight increased by one.

New games should be accounted for, and games are removed from the weights list when they are marked complete.

### Notes

The games list could get super big. But 64 bit lua is probably good for it. Could test and see if it gets nasty with a massive list over a long time if it comes to that.