### PR TITLE
BizHawk 2.6.3+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Bizhawk Shuffler 2
 * written by authorblues, inspired by [Brossentia's Bizhawk Shuffler](https://github.com/brossentia/BizHawk-Shuffler), based on slowbeef's original project
-* [tested on Bizhawk v2.6.2](https://github.com/TASVideos/BizHawk/releases/tag/2.6.2)  
-  **Important:** BizHawk v2.6.3 is currently not supported
+* [tested on Bizhawk v2.6.3-v2.8](https://github.com/TASVideos/BizHawk/releases/)  
 * [click here to download the latest version](https://github.com/authorblues/bizhawk-shuffler-2/archive/refs/heads/main.zip)
 
 ## Additional Resources

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -45,12 +45,11 @@ plugin.description =
 	- Rockman 8 GB / Rockman X4 GBC
 ]]
 
-local prevdata = {}
 local NO_MATCH = 'NONE'
 
-local swap_scheduled = false
-
-local shouldSwap = function() return false end
+local prevdata
+local swap_scheduled
+local shouldSwap
 
 -- update value in prevdata and return whether the value has changed, new value, and old value
 -- value is only considered changed if it wasn't nil before
@@ -575,6 +574,10 @@ function plugin.on_setup(data, settings)
 end
 
 function plugin.on_game_load(data, settings)
+	prevdata = {}
+	swap_scheduled = false
+	shouldSwap = function() return false end
+
 	local tag = data.tags[gameinfo.getromhash()] or get_game_tag()
 	data.tags[gameinfo.getromhash()] = tag or NO_MATCH
 

--- a/plugins/solo-z3r-multiworld.lua
+++ b/plugins/solo-z3r-multiworld.lua
@@ -24,8 +24,8 @@ plugin.description =
 	TIP: Generate seeds with unique sprites and name the players according to the sprites, so that send/recv messages will be meaningful and easily understood.
 ]]
 
-local this_player_id = -1
-local this_seed = -1
+local this_player_id
+local this_seed
 
 local ROM_NAME_ADDR = 0x7FC0 -- 15 bytes
 local ROM_NAME_PATTERN = { nil, nil, nil, nil, nil, 0x5F, nil, 0x5F, nil, 0x5F }
@@ -159,6 +159,9 @@ function plugin.on_setup(data, settings)
 end
 
 function plugin.on_game_load(data, settings)
+	this_player_id = -1
+	this_seed = -1
+
 	-- a handful of checks to make sure this is a SNES game first
 	local has_cartrom = false
 	for i,domain in ipairs(memory.getmemorydomainlist()) do

--- a/plugins/solo-zootr-multiworld.lua
+++ b/plugins/solo-zootr-multiworld.lua
@@ -28,9 +28,7 @@ plugin.description =
 	- Spikevegeta for streaming ZOOTR shuffler and making everybody say "it would be cool if they shared items"
 ]]
 
-local rando_context
-local coop_context = -1
-local player_num = -1
+local player_num
 
 local incoming_player_addr
 local incoming_item_addr
@@ -132,9 +130,9 @@ local function try_fill_names()
 end
 
 local function try_setup(data)
-    rando_context = mainmemory.read_u32_be(0x1C6E90 + 0x15D4) - 0x80000000
+    local rando_context = mainmemory.read_u32_be(0x1C6E90 + 0x15D4) - 0x80000000
     if rando_context < 0 then return false end
-    coop_context = mainmemory.read_u32_be(rando_context + 0x0000) - 0x80000000
+    local coop_context = mainmemory.read_u32_be(rando_context + 0x0000) - 0x80000000
 	if coop_context < 0 then return false end
 
     -- check protocol version
@@ -174,6 +172,7 @@ function plugin.on_setup(data, settings)
 end
 
 function plugin.on_game_load(data, settings)
+	player_num = -1
 	-- this should forcibly debounce the L press
 	data.prevL = true
 end

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -41,6 +41,9 @@ function log_message(msg, quiet)
 	handle:close()
 end
 
+-- for Lua 5.1 and 5.4 compatibility
+local unpack = table.unpack or unpack
+
 local function safe_log_format(format, ...)
 	local count = select('#', ...)
 	if count == 0 then return format end

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -202,9 +202,9 @@ function get_games_list(force)
 			fp:close()
 
 			-- bizhawk multidisk bundle
-			if xml:find('BizHawk--XMLGame') then -- double hyphen to escape literal hyphen
+			if xml:find('BizHawk%-XMLGame') then
 				for asset in xml:gfind('<Asset.-FileName="(.-)".-/>') do
-					if asset:find('\.\\') == 1 then asset = asset:sub(3) end
+					asset = asset:gsub('^%.[\\/]', '')
 					table.insert(toremove, asset)
 				end
 			end
@@ -437,8 +437,9 @@ function ends_with(a, b)
 end
 
 function strip_ext(filename)
-	local ndx = filename:find("\.[^\.]*$")
-	return filename:sub(1, ndx-1)
+	-- only return first ret value from gsub!
+	local name = filename:gsub('%.[^.]*$', '')
+	return name
 end
 
 -- returns positive number if curversion > reqversion,

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -603,6 +603,8 @@ function complete_setup()
 	-- whatever the current state is, update the output file
 	output_completed()
 
+	client.displaymessages(false)
+
 	-- if there is already a listed current game, this is a resumed session
 	-- otherwise, call swap_game() to setup for the first game load
 	if config.current_game ~= nil then

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -597,6 +597,7 @@ function complete_setup()
 		log_message('deleting savestates!')
 		delete_savestates()
 	end
+	make_dir(STATES_FOLDER)
 
 	-- whatever the current state is, update the output file
 	output_completed()

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -1,7 +1,7 @@
 --[[
 	Bizhawk Shuffler 2 by authorblues
 	inspired by Brossentia's Bizhawk Shuffler, based on slowbeef's original project
-	tested on Bizhawk v2.6.2 - http://tasvideos.org/BizHawk/ReleaseHistory.html
+	tested on Bizhawk v2.8 - http://tasvideos.org/BizHawk/ReleaseHistory.html
 	released under MIT License
 --]]
 

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -366,7 +366,7 @@ function get_next_game()
 end
 
 -- save current game's savestate, backup config, and load new game
-function swap_game(next_game)
+function swap_game(next_game, is_gui_callback)
 	log_debug('swap_game(%s): running=%s', next_game, running)
 	-- if a swap has already happened, don't call again
 	if not running then return false end
@@ -402,7 +402,7 @@ function swap_game(next_game)
 	client.SetSoundOn(false)
 
 	-- force another frame to pass to get the mute to take effect
-	if is_rom_loaded() then emu.frameadvance() end
+	if not is_gui_callback and is_rom_loaded() then emu.frameadvance() end
 
 	-- unique game count, for debug purposes
 	config.game_count = 0
@@ -609,7 +609,7 @@ function complete_setup()
 		load_game(config.current_game)
 	else
 		running = true
-		swap_game()
+		swap_game(nil, true)
 	end
 end
 

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -14,6 +14,9 @@ plugins = {}
 _PLATFORMS = {['dll'] = 'WIN', ['so'] = 'LINUX', ['dylib'] = 'MAC'}
 PLATFORM = _PLATFORMS[package.cpath:match("%p[\\|/]?%p(%a+)")]
 
+-- set in Lua console for verbose debug messages
+--SHUFFLER_DEBUG = true
+
 PLUGINS_FOLDER = 'plugins'
 GAMES_FOLDER = 'games'
 PREMADE_STATES = 'start-states'
@@ -35,6 +38,40 @@ function log_message(msg, quiet)
 	handle:write(tostring(msg))
 	handle:write('\n')
 	handle:close()
+end
+
+local function safe_log_format(format, ...)
+	local count = select('#', ...)
+	if count == 0 then return format end
+
+	local arguments = {...}
+	-- deal with nil and boolean values which %s can't handle
+	for i = 1, count do
+		if (type(arguments[i]) ~= 'number') then
+			arguments[i] = tostring(arguments[i])
+		end
+	end
+
+	local success, result = pcall(string.format, format, unpack(arguments))
+	if success then
+		return result
+	else
+		return string.format('Log error at "%s": %s', tostring(format), tostring(result))
+	end
+end
+
+function log_console(format, ...)
+	log_message(safe_log_format(format, ...), false)
+end
+
+function log_quiet(format, ...)
+	log_message(safe_log_format(format, ...), true)
+end
+
+function log_debug(format, ...)
+	if SHUFFLER_DEBUG then
+		log_message(safe_log_format(format, ...), true)
+	end
 end
 
 -- check if folder exists

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -27,6 +27,7 @@ DEFAULT_CMD_OUTPUT = 'shuffler-src/.cmd-output.txt'
 MIN_BIZHAWK_VERSION = "2.6.3"
 MAX_BIZHAWK_VERSION = nil
 RECOMMENDED_LUA_CORE = "LuaInterface"
+UNSUPPORTED_LUA_CORE = "NLua"
 MAX_INTEGER = 99999999
 
 function log_message(msg, quiet)
@@ -472,7 +473,7 @@ function checkversion(reqversion, curversion)
 end
 
 local function check_compatibility()
-	if client.get_lua_engine() ~= RECOMMENDED_LUA_CORE then
+	if client.get_lua_engine() == UNSUPPORTED_LUA_CORE then
 		log_message(string.format("\n[!] It is recommended to use the %s core (currently using %s)\n" ..
 			"Change the Lua core in the Config > Customize > Advanced menu and restart BizHawk",
 			RECOMMENDED_LUA_CORE, client.get_lua_engine()))

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -560,14 +560,15 @@ function complete_setup()
 			local pmodule = require(PLUGINS_FOLDER .. '.' .. pmodpath)
 			if checkversion(pmodule.minversion) then
 				log_message('Plugin loaded: ' .. pmodule.name)
+				table.insert(plugins, pmodule)
+				if pmodule.on_setup ~= nil then
+					pmodule.on_setup(pdata.state, pdata.settings)
+				end
 			else
 				log_message(string.format('%s requires Bizhawk version %s+', pmodule.name, pmodule.minversion))
 				log_message("-- Currently installed version: " .. client.getversion())
 				log_message("-- Please update your Bizhawk installation to use this plugin")
 				config.plugins[pmodpath] = nil
-			end
-			if pmodule ~= nil and pmodule.on_setup ~= nil then
-				pmodule.on_setup(pdata.state, pdata.settings)
 			end
 		end
 	end

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -15,7 +15,7 @@ plugins = {}
 
 -- determine operating system for the purpose of commands
 _PLATFORMS = {['dll'] = 'WIN', ['so'] = 'LINUX', ['dylib'] = 'MAC'}
-PLATFORM = _PLATFORMS[package.cpath:match("%p[\\|/]?%p(%a+)")]
+PLATFORM = _PLATFORMS[(package.cpath..';'):match('%.(%a+);')]
 
 PLUGINS_FOLDER = 'plugins'
 GAMES_FOLDER = 'games'


### PR DESCRIPTION
Support BizHawk 2.63+, biggest change being that `client.openrom` no longer restarts the script.

Also support Lua 5.4 introduced in BizHawk 2.9

Resolve #54 