### PR TITLE
MMXTreme 1 and 2 - address Options menu shuffles and character swaps

### DIFF
--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -130,8 +130,8 @@ local function generic_swap(gamemeta)
 
 		-- Sometimes you want to swap for things that don't cost hp or lives, like non-standard game overs.
 		-- If a method is provided for other_swaps and its conditions are true, cue up a swap.
-		if gamemeta.other_swaps and gamemeta.other_swaps() then
-			data.hpcountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			return gamemeta.other_swaps()
 		end
 
 		return false

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -364,7 +364,8 @@ local gamedata = {
 	},
 	['mmx1gbc']={ -- Mega Man Xtreme GBC
 		gethp=function() return bit.band(memory.read_u8(0x0ADC, "WRAM"), 0x7F) end,
-		getlc=function() return memory.read_u8(0x1365, "WRAM") end,
+		getlc=function() return memory.read_u8(0x1365, "WRAM") % 255 end,
+		-- Prevent shuffle on selecting Retry. Lives go from 0 to 255 on losing your last life, then "drop" from 255 to 2 on starting again.
 		maxhp=function() return memory.read_u8(0x1384, "WRAM") end,
 	},
 	['mmx2gbc']={ -- Mega Man Xtreme 2 GBC

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -381,13 +381,13 @@ local gamedata = {
 			if character_changed then 
 				return true
 			end
-			local options_changed, options_curr = update_prev("options", memory.read_u8(0x0A6A, "WRAM") == 4 or memory.read_u8(0x0A6A, "WRAM") == 5)
+			local menu_selection = memory.read_u8(0x0A6A, "WRAM")
 			-- This address holds your selection on the opening screen.
 			-- 0 == Extreme Mode, 1 = X, 2 = Zero, 3 = Continue, 4 = Options, 5 = Boss Attack
 			-- If you go to the Options screen (4) or enter Boss Attack mode, lives will drop to 0
 			-- because you get no extra lives in Boss Attack.
 			-- So, we should never swap until being outside of selecting those modes.
-			if options_curr then
+			if menu_selection == 4 or menu_selection == 5 then
 				return true
 			end
 			local maxhp_changed = update_prev("maxhp", memory.read_u8(0x0084, "WRAM"))

--- a/plugins/megaman-damage-shuffler.lua
+++ b/plugins/megaman-damage-shuffler.lua
@@ -103,6 +103,12 @@ local function generic_swap(gamemeta)
 		data.prevhp = currhp
 		data.prevlc = currlc
 
+		-- Sometimes you will want to update hp and lives without triggering a swap (e.g., on swapping between characters).
+		-- If a method is provided for swap_exceptions and its conditions are true, process the hp and lives but don't swap.
+		if gamemeta.swap_exceptions and gamemeta.swap_exceptions() then
+			return false
+		end
+
 		-- this delay ensures that when the game ticks away health for the end of a level,
 		-- we can catch its purpose and hopefully not swap, since this isnt damage related
 		if data.hpcountdown ~= nil and data.hpcountdown > 0 then
@@ -120,6 +126,12 @@ local function generic_swap(gamemeta)
 		-- check to see if the life count went down
 		if prevlc ~= nil and currlc < prevlc then
 			return true
+		end
+
+		-- Sometimes you want to swap for things that don't cost hp or lives, like non-standard game overs.
+		-- If a method is provided for other_swaps and its conditions are true, cue up a swap.
+		if gamemeta.other_swaps and gamemeta.other_swaps() then
+			data.delayCountdown = gamemeta.delay or 3
 		end
 
 		return false


### PR DESCRIPTION
This should address issue #66 (which, by the way, had an extremely helpful clip of the problem!)

This adds a couple of flexible options to generic_swap to swap/not swap after HP and lives are processed. If a method isn't given, nothing happens, like with gmode. These could be useful for other scenarios.

MMXTreme 1
I couldn't replicate the swap on the Options menu, but it absolutely was happening on hitting Retry on a game over. It's because your lives "drop" to 255, or -1 if it's considered a signed byte. You do swap on losing your last life. This doesn't need those generic_swap changes.

MMXTreme 2
The same lives-as-signed-byte fix was needed as for MMXTreme 1. 

In addition, going into Options or Boss Attack sets your lives to 0. This causes a wrong swap. Used swap_exceptions on this.

Also, Boss Attack sets your maxhp to 32, and if you fire up a game with less than 32 maxhp (like 16 on a new game), you'll swap because hp dropped. Used swap_exceptions to address this.

Finally, fixed a problem where you swap if you tag in X/Zero and they have less HP than the character you had been using. swap_exceptions is true on the frame where the character and HP switch together.