### PR TITLE
Weighted odds

### DIFF
--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -248,7 +248,8 @@ function module.initial_setup(callback)
 
 	local SWAP_MODES_RANDOM = 'Random Order (Default)'
 	local SWAP_MODES_FIXED = 'Fixed Order'
-	local SWAP_MODES = {[SWAP_MODES_RANDOM] = -1, [SWAP_MODES_FIXED] = 0}
+	local SWAP_MODES_WEIGHTED = 'Random Order, Weighted Odds'
+	local SWAP_MODES = {[SWAP_MODES_RANDOM] = -1, [SWAP_MODES_FIXED] = 0, [SWAP_MODES_WEIGHTED] = -2}
 
 	local OUTPUT_FILE_MODES_DEFAULT = 2
 	local OUTPUT_FILE_MODES = {
@@ -299,6 +300,17 @@ function module.initial_setup(callback)
 
 		config.completed_games = {}
 
+		if config.shuffle_index == -2 then
+
+			config.total_tickets = {}
+			config.last_ticket = {}
+			for _,game in pairs(get_games_list()) do
+				config.total_tickets[game] = 1
+				config.last_ticket[game] = tonumber(_) + 1
+			end
+
+		end
+
 		config.plugins = {}
 		for _,plugin in ipairs(plugins) do
 			if plugin._enabled then
@@ -323,7 +335,7 @@ function module.initial_setup(callback)
 	function save_mutable_settings()
 		-- only set config.shuffle_index if mode has changed or was nil (new config)
 		local new_shuffle_mode = SWAP_MODES[forms.gettext(mode_combo)]
-		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or -1)
+		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or -1 or -2)
 		if cur_shuffle_mode ~= new_shuffle_mode then
 			config.shuffle_index = new_shuffle_mode
 		end

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -300,17 +300,6 @@ function module.initial_setup(callback)
 
 		config.completed_games = {}
 
-		if config.shuffle_index == -2 then
-			
-			local all_games = get_games_list()
-			config.total_tickets = #all_games
-			config.tickets = {}
-			for _,game in pairs(all_games) do
-				config.tickets[game] = 1
-			end
-
-		end
-
 		config.plugins = {}
 		for _,plugin in ipairs(plugins) do
 			if plugin._enabled then
@@ -335,7 +324,7 @@ function module.initial_setup(callback)
 	function save_mutable_settings()
 		-- only set config.shuffle_index if mode has changed or was nil (new config)
 		local new_shuffle_mode = SWAP_MODES[forms.gettext(mode_combo)]
-		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or -1 or -2)
+		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or config.shuffle_index)
 		if cur_shuffle_mode ~= new_shuffle_mode then
 			config.shuffle_index = new_shuffle_mode
 		end

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -248,7 +248,7 @@ function module.initial_setup(callback)
 
 	local SWAP_MODES_RANDOM = 'Random Order (Default)'
 	local SWAP_MODES_FIXED = 'Fixed Order'
-	local SWAP_MODES_WEIGHTED = 'Random Order, Weighted Odds'
+	local SWAP_MODES_WEIGHTED = 'Weighted Odds'
 	local SWAP_MODES = {[SWAP_MODES_RANDOM] = -1, [SWAP_MODES_FIXED] = 0, [SWAP_MODES_WEIGHTED] = -2}
 
 	local OUTPUT_FILE_MODES_DEFAULT = 2
@@ -301,12 +301,12 @@ function module.initial_setup(callback)
 		config.completed_games = {}
 
 		if config.shuffle_index == -2 then
-
-			config.total_tickets = {}
-			config.last_ticket = {}
-			for _,game in pairs(get_games_list()) do
-				config.total_tickets[game] = 1
-				config.last_ticket[game] = tonumber(_) + 1
+			
+			local all_games = get_games_list()
+			config.total_tickets = #all_games
+			config.tickets = {}
+			for _,game in pairs(all_games) do
+				config.tickets[game] = 1
 			end
 
 		end
@@ -407,7 +407,7 @@ function module.initial_setup(callback)
 	mode_combo = forms.dropdown(setup_window, invert_table(SWAP_MODES), 10, y, 150, 20)
 	forms.label(setup_window, "Shuffler Swap Order", 165, y+3, 150, 20)
 	local select_fixed_order = config.shuffle_index and config.shuffle_index > -1
-	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or SWAP_MODES_RANDOM)
+	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or SWAP_MODES_RANDOM or SWAP_MODES_WEIGHTED)
 	y = y + 30
 
 	hk_complete = forms.dropdown(setup_window, HOTKEY_OPTIONS, 10, y, 150, 20)

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -325,7 +325,6 @@ function module.initial_setup(callback)
 		-- only set config.shuffle_index if mode has changed or was nil (new config)
 		local new_shuffle_mode = SWAP_MODES[forms.gettext(mode_combo)]
 		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or config.shuffle_index)
-		
 		if cur_shuffle_mode ~= new_shuffle_mode then
 			config.shuffle_index = new_shuffle_mode
 		end
@@ -397,8 +396,7 @@ function module.initial_setup(callback)
 	mode_combo = forms.dropdown(setup_window, invert_table(SWAP_MODES), 10, y, 150, 20)
 	forms.label(setup_window, "Shuffler Swap Order", 165, y+3, 150, 20)
 	local select_fixed_order = config.shuffle_index and config.shuffle_index > -1
-	local select_random_order = config.shuffle_index == -2 and SWAP_MODES_WEIGHTED or SWAP_MODES_RANDOM
-	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or select_random_order)
+	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or SWAP_MODES_RANDOM or SWAP_MODES_WEIGHTED)
 	y = y + 30
 
 	hk_complete = forms.dropdown(setup_window, HOTKEY_OPTIONS, 10, y, 150, 20)

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -325,6 +325,7 @@ function module.initial_setup(callback)
 		-- only set config.shuffle_index if mode has changed or was nil (new config)
 		local new_shuffle_mode = SWAP_MODES[forms.gettext(mode_combo)]
 		local cur_shuffle_mode = config.shuffle_index and (config.shuffle_index >= 0 and 0 or config.shuffle_index)
+		
 		if cur_shuffle_mode ~= new_shuffle_mode then
 			config.shuffle_index = new_shuffle_mode
 		end
@@ -396,7 +397,8 @@ function module.initial_setup(callback)
 	mode_combo = forms.dropdown(setup_window, invert_table(SWAP_MODES), 10, y, 150, 20)
 	forms.label(setup_window, "Shuffler Swap Order", 165, y+3, 150, 20)
 	local select_fixed_order = config.shuffle_index and config.shuffle_index > -1
-	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or SWAP_MODES_RANDOM or SWAP_MODES_WEIGHTED)
+	local select_random_order = config.shuffle_index == -2 and SWAP_MODES_WEIGHTED or SWAP_MODES_RANDOM
+	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or select_random_order)
 	y = y + 30
 
 	hk_complete = forms.dropdown(setup_window, HOTKEY_OPTIONS, 10, y, 150, 20)

--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -396,7 +396,8 @@ function module.initial_setup(callback)
 	mode_combo = forms.dropdown(setup_window, invert_table(SWAP_MODES), 10, y, 150, 20)
 	forms.label(setup_window, "Shuffler Swap Order", 165, y+3, 150, 20)
 	local select_fixed_order = config.shuffle_index and config.shuffle_index > -1
-	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or SWAP_MODES_RANDOM or SWAP_MODES_WEIGHTED)
+	local select_random_order = config.shuffle_index == -2 and SWAP_MODES_WEIGHTED or SWAP_MODES_RANDOM
+	forms.settext(mode_combo, select_fixed_order and SWAP_MODES_FIXED or select_random_order)
 	y = y + 30
 
 	hk_complete = forms.dropdown(setup_window, HOTKEY_OPTIONS, 10, y, 150, 20)

--- a/shuffler.lua
+++ b/shuffler.lua
@@ -382,9 +382,8 @@ function get_next_game()
 		if config.shuffle_index == -1 then
 			return all_games[math.random(#all_games)]
 		elseif config.shuffle_index == -2 then
-			return weighted_shuffle(prev, all_games)
+			return weighted_shuffle(all_games)
 		end
-		
 	else
 		-- manually select the next one
 		config.shuffle_index = (config.shuffle_index % #all_games) + 1
@@ -392,51 +391,26 @@ function get_next_game()
 	end
 end
 
-function weighted_shuffle(prev, all_games)
-	
-	--Here's how the weighted odds work. I don't know the best way to put it into words.
-	--total_tickets tracks how many tickets each game has.
-	--last_ticket tracks the 'highest number' ticket assigned to that game.
-	--Every time we pull a game, the last game loses all its tickets. ALl other games get +1 ticket.
-	--We reassign tickets to each game, in order, and use the running total to keep track of each games 'highest ticket.'
-	--If the 'winning ticket' is less than the games' 'highest ticket,' it wins and gets picked. Lowest such game wins.
-	--i.e. "Game B" just got picked, so it has 0 tickets. "Game A" has 3 tickets. "Game B" has 0 tickets. "Game C" has 9 tickets, "Game D" has 4.
-	--Game A's highest ticket is 3 (0 running total + 3 tickets), Game B is also 3 (it has no tickets), Game C's highest ticket is 12 (3 running total + 9 tickets), Game D is 16 (12 running total + 4)
-	--The random number chosen is 3. Iterate over the array.
-	--Game A's max ticket is 3. The winning ticket is 3. Game A wins. Because it was processed first, Game B doesn't get checked, and Game A is selected.
-	--Same values, but the random number chosen is 6.
-	--Game A's max ticket is 3; it didn't win. Game B's max ticket is also 3, it also doesn't win. Game C's max ticket is 12; 6 <= 12, Game C wins.
-	--So A wins on tickets 1-3, B can't win, C wins on tickets 4-12, D wins on 13-16.
-	--Does that make any sense?
 
-	--index starts at 1, starting with 0 'tickets' in the pot.
+function weighted_shuffle(all_games)
+
 	local runningTotal = 0
-	local winningTicket = 0
-
-	print("\n\n ::::: Time to pick a new game! :::::\n")
-	if prev ~= nil then config.total_tickets[prev] = 0 end
-
-	--update ticket counts
-	for _, game in ipairs(all_games) do
-		config.total_tickets[game] = config.total_tickets[game] + 1
-		runningTotal = runningTotal + config.total_tickets[game]
-		config.last_ticket[game] = runningTotal
-		print(tostring(game) .. " total_tickets = " .. config.total_tickets[game] .. ", last_ticket = " .. config.last_ticket[game] .. "\n")
-	end
-
-	--pull a ticket...
-	winningTicket = math.random(runningTotal)
-	print("\n\n !!! The winning ticket is " .. winningTicket .. " !!!")
-	--unfortunately, we have to iterate -twice- because we don't know the max ticket count until we assign tickets.
-	for _, game in ipairs(all_games) do
-		if winningTicket <= config.last_ticket[game] then
-			print("\n !!! Time to play " .. tostring(game) .. " !!!")
-			return game
-		end
-	end
+	local winningTicket = math.random(1, config.total_tickets)
+	local winningGame = nil
 	
-end --end weighted_shuffle function
+	for _, game in ipairs(all_games) do --iterate the game list
+		if winningTicket <= (runningTotal + config.tickets[game]) and winningGame == nil then --This game wins! but only if there's no winning game set already!
+			winningGame = game
+			config.tickets[game] = 0
+		end
 
+		config.tickets[game] = config.tickets[game] +1
+		runningTotal = runningTotal + config.tickets[game]
+	end --end iterating game list
+
+	config.total_tickets = runningTotal
+	return winningGame
+end --end weighted_shuffle function
 
 -- save current game's savestate, backup config, and load new game
 function swap_game(next_game)


### PR DESCRIPTION
RE: https://github.com/authorblues/bizhawk-shuffler-2/issues/83 https://github.com/authorblues/bizhawk-shuffler-2/pull/56

This adds a Weighted Odds shuffle option to the shuffler, that may help the Shuffler's shuffles 'feel' more random even if they're not perfectly, evenly random.

In short, each game in the list starts with one ticket. On game swap, a number is chosen at random, and the game with the winning ticket is the next game. That game also loses all of its tickets.

Every game that is not selected as the next game is given one additional ticket. The longer a game goes without being selected, the more likely it is to be chosen. This boils down to "Number of swaps since game was last played" out of "Total Number of Swaps since all games were last played" odds of being selected next.

The only thing I cannot seem to iron out is that the Shuffler's settings window doesn't 'remember' that you've picked Weighted Odds between sessions, and reverts to the default Random Shuffle when you boot it up again; this should really be addressed before the option is added.

Apologies for reposting this, I renamed the branches on my git and that closed out the pull request.