### PR TITLE
Make generated config file more readable

### DIFF
--- a/shuffler.lua
+++ b/shuffler.lua
@@ -109,13 +109,13 @@ end
 
 -- dump lua object
 function dump(o)
-	function _dump(o, a, b)
+	function _dump(o, a, b, n)
 		if type(o) == 'table' then
 			local s = ''
 			for k,v in pairs(o) do
-				s = s..a..string.format('[%s] = %s,', _dump(k, "", ""), _dump(v, "", ""))..b
+				s = s..string.rep(a, n)..string.format('[%s] = %s,', _dump(k, "", "", 0), _dump(v, a, b, n+1))..b
 			end
-			return '{'..b..s..'}'..b
+			return (s == '' and '{}' or '{'..b..s..string.rep(a, n-1)..'}')..(n == 1 and b or '')
 		elseif type(o) == 'number' or type(o) == 'boolean' or o == nil then
 			return tostring(o)
 		elseif type(o) == 'string' then
@@ -126,7 +126,7 @@ function dump(o)
 		end
 	end
 
-	return _dump(o, "\t", "\n")
+	return _dump(o, "\t", "\n", 1)
 end
 
 -- saves primary config file


### PR DESCRIPTION
This PR updates `dump()` to properly indent nested tables (as values) and is intended to make the generated `shuffler-src/config.lua` more human-readable.

At present, the 'top level' config table is indented, however any contained tables are all output on a single line. This causes readability issues both for large game lists and also for using plugins, which have their own namespaced settings tables.

If there's a need to view/change settings during a shuffler run, this could pose a problem.

With this change, the recursive printing will apply the correct level of indentation for each nested table using repetitions of the prefix string `a` (`\t` here). (for reference, `string.rep(s, n)` is defined as returning the empty string for non-positive n)
(**Edit:** Lua 5.1 is less clear on the behaviour of `string.rep` then I thought it was, this may need double-checking just in case)

Other points of note:
* Empty tables now only output as `{}` rather than `{b}`
* The trailing `b` (i.e. `\n`) is only appended for a top-level table.
  (This is equivalent in behaviour to the current code, as all other nestings had an empty string for `b`)

These changes are needed to prevent extra newlines getting inserted, as for tables part of key-value pairs there is already an instance of `b` inserted after the trailing `,` following the value.

Does nothing for tables used as keys, because I feel that might make the output too confusing and also "who is doing this anyway?".