### PR TITLE
Add utility function to check hash database for missing tags

### DIFF
--- a/shuffler.lua
+++ b/shuffler.lua
@@ -707,15 +707,41 @@ function complete_setup()
 	end
 end
 
+local HASH_DB_PATTERN = "^([0-9A-Fa-f]+)%s+(%S+)"
+
 function get_tag_from_hash_db(target, database)
 	local resp = nil
 	local fp = assert(io.open(database, 'r'))
 	for x in fp:lines() do
-		local hash, tag = x:match("^([0-9A-Fa-f]+)%s+(%S+)")
+		local hash, tag = x:match(HASH_DB_PATTERN)
 		if hash == target then resp = tag; break end
 	end
 	fp:close()
 	return resp
+end
+
+function compare_with_hash_db(_table, database)
+	local not_table, not_db = {}, {}
+	local in_db = {}
+	
+	local fp = assert(io.open(database, 'r'))
+	for x in fp:lines() do
+		local _, tag = x:match(HASH_DB_PATTERN)
+		if not _table[tag] then
+			table.insert(not_table, tag)
+		else
+			in_db[tag] = true
+		end
+	end
+	fp:close()
+	
+	for tag,_ in pairs(_table) do
+		if not in_db[tag] then
+			table.insert(not_db, tag)
+		end
+	end
+	
+	return not_table, not_db
 end
 
 if not check_compatibility() then


### PR DESCRIPTION
As much of a suggestion with code attached as anything else, so it's open to changes around the concept and implementation.

For the benefit of the damage shuffler plugins that use the "hash database" format, this adds a function that takes [a table which maps tags to 'truthy' values] and [a hash -> tag db file] and returns two lists, which are the relative differences of the sets of tags in each (i.e. tags in the file but **not** the table, and tags in the table but **not** the file). If both sets are the same, the lists will be empty.

This is specifically and probably exclusively useful for validating the consistency of these files, especially around bulk additions where it's easy for a missing tag to go unnoticed until later when things break.

However, a) it's hard to do this other ways, b) code locality here is good for consistency, c) these mistakes do keep happening.