### PR TITLE
Allow specifying order for dropdown menu items

### DIFF
--- a/shuffler-src/setupform.lua
+++ b/shuffler-src/setupform.lua
@@ -62,6 +62,7 @@ function module.make_plugin_window(plugins)
 		['select'] = {
 			make = function(plugin, win, setting, x, y)
 				setting.input = forms.dropdown(win, setting.options, x, y, 150, 20)
+				if setting.ordered then forms.setdropdownitems(setting.input, setting.options, false) end
 				if setting.default then forms.settext(setting.input, setting.default) end
 				if setting._value then forms.settext(setting.input, setting._value) end
 				local label = forms.label(win, setting.label, x+155, y+3, 150, 20)


### PR DESCRIPTION
This adds a new optional property `ordered` for dropdown-type settings, which allows specifying the order the dropdown items should appear in. Currently, all dropdown items are unconditionally sorted alphabetically and it would be good to have a way to override this (somewhat unexpected) behaviour for settings that may have a logical ordering that is non-alphabetical.

With this change, if `ordered = true` is defined, `options` will be taken to be an ordered list and passed to `setdropdownitems` as such. Otherwise, existing behaviour is preserved.

The corresponding wiki page will also need updating to mention the additional `ordered` key for `select` type options.

Example usage:
```lua
{ name='testing', type='select', label="test setting please ignore", options={'la','li','lu','le','lo'}, ordered=true }
```