### PR TITLE
Add logging to savestate operations

### DIFF
--- a/shuffler.lua
+++ b/shuffler.lua
@@ -335,7 +335,10 @@ function save_current_game()
 		end
 		overwrite(statename, statename .. '.bk1')
 		log_debug('save_current_game: save "%s"', statename)
-		savestate.save(statename)
+		-- compare against false due to void return on older BizHawk versions
+		if savestate.save(statename) == false then
+			log_console('Failed to save state: %s', statename)
+		end
 	end
 end
 
@@ -360,7 +363,12 @@ local function on_game_load()
 	local state = get_savestate_file()
 	if file_exists(state) then
 		log_debug('on_game_load: load state "%s"', state)
-		savestate.load(state)
+		-- compare against false due to void return on older BizHawk versions
+		if savestate.load(state) == false then
+			log_console('Failed to load state: %s', state)
+		end
+	else
+		log_debug('on_game_load: missing state "%s"', state)
 	end
 
 	-- update swap counter for this game


### PR DESCRIPTION
 This adds backwards compatible success checks and logging to `savestate.load/save` usage in a similar way to the `client.openrom` call in `load_game`.
A debug log call is also made in the event the savestate file is not found - as this may simply be due to a fresh load of a game it does not necessarily indicate a problem, so it's not logged to the console ('quiet' logging could also be an option here).

It seems there may be some infrequent issue causing savestates to be lost and it would be good to have some more information to pin this down somewhat.